### PR TITLE
feat: mobile SNS 로그인 제약조건 1종 추가, kakao/naver인앱 호출 로직 추가, 공통함수 처리, sns 응답 처리

### DIFF
--- a/app/Http/Controllers/LoginController.php
+++ b/app/Http/Controllers/LoginController.php
@@ -188,12 +188,12 @@ class LoginController extends BaseController
             'name' => $request->input('name'),
             'email' => $request->input('email'),
             'phone_number' => str_replace("-", "", trim($request->input('phone_number'))),
-            'provider' => $request->input('provider'),
+            'provider' => $request->input('provider', 'google|naver|kakao'),
             'id' => $request->input('id'),
         ];
 
         $userInfo = $this->loginService->getSocialUserInfo($socialUserData);
-
+        
         // if ($socialUserData['provider'] == "naver") {
         //     $social = new SocialController();
         //     $social->naverLogout($request);
@@ -239,10 +239,13 @@ class LoginController extends BaseController
                     'not_approve' => 'use after approve.',
                 ]);
         } else {
+            $count = $this->loginService->countSocialUserInfo($socialUserData);
+            if($count > 1) {
+                // 이메일 or 전화번호 기준 가입 회원이 n명일 경우 목록 화면으로 보낸다.
+                return redirect('/signin/choose-ids?cellphone=' . $userInfo->phone_number);
+            }
             $this->loginService->getAuthToken($userInfo->idx);
             if ($userInfo->type == "W" && $userInfo->isFirst > 1) {
-
-
                 return redirect(getDeviceType() . '/mypage');
             } else {
                 Log::info("#####################################");

--- a/app/Http/Controllers/SocialController.php
+++ b/app/Http/Controllers/SocialController.php
@@ -316,7 +316,7 @@ class SocialController extends BaseController
             'name' => $request->name,
             'email' => $request->email, 
             'phone_number' => $request->phone_number,
-            'provider' => 'google',
+            'provider' => 'google|naver|kakao',
             'id' => $request->id
          ];
  

--- a/app/Service/LoginService.php
+++ b/app/Service/LoginService.php
@@ -62,6 +62,24 @@ class LoginService
         return $user;
     }
 
+    public function countSocialUserInfo(array $params = [])
+    {
+	    $params['phone_number'] = preg_replace('/^\+82\s?/', '0', $params['phone_number']) ?? 'none';
+
+        $countUsers = DB::table('AF_user', 'u')
+            ->select(DB::raw("u.idx, u.account, u.name, u.type, u.state, u.is_owner,
+            IF((select count(*) from AF_user_agreement ag where ag.user_idx = u.idx and ag.is_agree = 1) < 2, 1, 0) AS isNeedAgreement,
+            IF((select count(*) from AF_user_access ac where ac.user_idx = u.idx) < 1, 1, 0) AS isFirst"))
+            ->where('u.state', 'JS')
+            ->where(function($query) use($params) {
+                $query->where('account', $params['email'] ?? '')
+                    ->orWhereRaw("REPLACE(phone_number, '-', '') = '".str_replace('-', '', $params['phone_number'])."'");
+            })
+            ->count();
+
+        return $countUsers;
+    }
+
     public function getAuthToken(string $idx) {
         if ($idx == null) { return null;}
 

--- a/resources/views/m/login/choose_login_ids.blade.php
+++ b/resources/views/m/login/choose_login_ids.blade.php
@@ -16,13 +16,15 @@ $header_banner = '';
     <section class="login_common flex items-center">
         <div class="login_inner">
             <img class="logo" src="/img/logo.svg" alt="">
+            <div class="joined_id_box">
                 @foreach($users as $user)
-                <div class="joined_id_box">
+                <div class="joined_id_item">
                     <input type="radio" name="joined_id" id="joined_id_@php echo $loop -> index; @endphp" value="@php echo $user->account; @endphp" 
                         @php echo ($loop -> index == 0 ? 'checked' : ''); @endphp>
                         <label for="joined_id_'+idx+'" onclick="console.log(1);return false;">@php echo $user->account; @endphp</label>
                 </div>
                 @endforeach
+            </div>
             <ul class="info_box">
                 <li>서비스 이용 및 회원가입 문의는 '서비스 이용문의(cs@all-furn.com)' 또는 031-813-5588로 문의 해주세요.</li>
             </ul>

--- a/resources/views/m/login/login.blade.php
+++ b/resources/views/m/login/login.blade.php
@@ -110,9 +110,9 @@ if('{{ $replaceUrl ?? "" }}' != '') {
                         <li>서비스 이용 및 회원가입 문의는 '서비스 이용문의(cs@all-furn.com)' 또는 031-813-5588로 문의 해주세요.</li>
                     </ul>
 
+                    <button type="submit" id="LGI-01_loginBtn" class="btn w-full btn-primary" disabled>로그인하기</button>
 <a href="{{ route('signUp') }}" class="btn w-full mt-2.5 btn-line2" style="    border-color: var(--main_color) !important;    color: var(--main_color) !important; margin-bottom: 0.625rem">올펀 가입하기</a>
 
-                    <button type="submit" id="LGI-01_loginBtn" class="btn w-full btn-primary" disabled>로그인하기</button>
                     </form>
                 </div>
 
@@ -151,6 +151,7 @@ if('{{ $replaceUrl ?? "" }}' != '') {
                     </ul>
 
                     <button id="btn_smscode_confirm" class="btn w-full btn-primary" onclick="confirmAuthCode()" disabled type="button">인증완료</button>
+
                     <a href="{{ route('signUp') }}" class="btn w-full mt-2.5 btn-line2" style="    border-color: var(--main_color) !important;    color: var(--main_color) !important; margin-bottom: 0.625rem">올펀 가입하기</a>
 
                     <button id="btn_selected_id_login" class="btn w-full btn-primary mt-2.5" style="display:none;" type="button" onclick="signin()">선택한 아이디로 로그인</button>
@@ -320,7 +321,6 @@ function confirmAuthCode() {
                 },
                 success : function(result) {
                     if (result.success) {
-                    
                         if(result.users.length > 0) {
                             location.replace('/signin/choose-ids?cellphone='+data.target);
                         } else {

--- a/resources/views/m/login/login_social.blade.php
+++ b/resources/views/m/login/login_social.blade.php
@@ -383,6 +383,8 @@ $("#naver").on('click', function (e) {
 function openNaverLogin() {
     // let naverLoginUrl = `{{ route('social.naver.login') }}`;
     // document.location = naverLoginUrl;
+    snsAppLogin('naver');
+    /*
     $.ajax({
         url: "{{ route('social.naver.login') }}",
         method: "GET",
@@ -393,6 +395,7 @@ function openNaverLogin() {
             alert('Failed to start Naver login process.');
         }
     });
+    */
 }
 
 //google 간편 로그인
@@ -402,28 +405,26 @@ $("#google").on('click', function (e) {
 });
 
 function openGoogleLogin() {
-    var jsonStr = '{ "type" : "sns", "snsType" : "google"}'; // 'X-CSRF-TOKEN': '{{csrf_token()}}'
-
-    if(isMobile.Android()) {
-    
-    window.AppWebview.postMessage(jsonStr);
-    } else if (isMobile.iOS()) {
-    window.webkit.messageHandlers.AppWebview.postMessage(jsonStr);
-    }
-   
+    snsAppLogin('google');
 }
-
-
-    // $.ajax({
-    //     url: "{{ route('social.google.login') }}",
-    //     method: "GET",
-    //     success: function (data) {
-    //         window.open(data.url, '_system');
-    //     },
-    //     error: function () {
-    //         alert('Failed to start google login process.');
-    //     }
-    // });
+function snsAppLogin(type) {
+    const payload = JSON.stringify({
+        type: "sns",
+        snsType: type
+    });
+    
+    if(isMobile.any() && !window.AppWebview && !(window.webkit && window.webkit.messageHandlers 
+        && window.webkit.messageHandlers.AppWebview)) {
+            
+        alert('인앱에서만 SNS 로그인이 가능합니다.');
+        return;
+    }
+    if(isMobile.Android()) {
+        window.AppWebview.postMessage(payload);
+    } else if (isMobile.iOS()) {
+        window.webkit.messageHandlers.AppWebview.postMessage(payload);
+    }
+}
 
 //kakao 간편 로그인
 $("#kakao").on('click', function (e) {
@@ -432,6 +433,8 @@ $("#kakao").on('click', function (e) {
 });
 
 function openKakaoLogin() {
+    snsAppLogin('kakao');
+    /*
     $.ajax({
         url: "{{ route('social.kakao.login') }}",
         method: "GET",
@@ -443,6 +446,7 @@ function openKakaoLogin() {
             alert('Failed to start kakao login process.');
         }
     });
+    */
 }
 
 </script>


### PR DESCRIPTION
- [ ] 모바일 SNS 로그인 시도 시 인앱이 아니라면 인앱 로그인을 이용하라는 앱 설치 유도 메시지 추가
- [ ] 모바일 구글 로직처럼 kakao / naver 인앱 호출부 로직 추가
- [ ] 해당 sns 모바일 호출부 재사용 함수로 처리
- [ ] sns 응답에 대해 성공했을 경우에 대한 처리 (kakao / naver)
- [ ] sns 로그인 시 이메일/전화번호가 중복이 존재할 경우(2개 이상) 목록 화면으로 이동하도록 처리